### PR TITLE
adding cores build arg

### DIFF
--- a/HADDOCK2.4/Dockerfile
+++ b/HADDOCK2.4/Dockerfile
@@ -10,6 +10,9 @@ USER root
 ## global env
 # ENV HOME=/home TERM=xterm
 
+## Set the number of cores you want cns/HADDOCK to use
+ARG CORES=24
+
 ## set proper timezone
 # RUN echo America/New_York > /etc/timezone && sudo dpkg-reconfigure --frontend noninteractive tzdata
 
@@ -83,6 +86,7 @@ RUN cd $HOME/haddock/cns_solve/intel-x86_64bit-linux/source && \
 
 ## Configure HADDOCK
 RUN cd $HOME/haddock/haddock2.4-2021-01 && \
+    sed -i s/NUMJOB=24/NUMJOB=$CORES/g local_config_file && \
     ./install.csh local_config_file
 
 ## Grant execution permissions to entire dir

--- a/HADDOCK2.4/README.md
+++ b/HADDOCK2.4/README.md
@@ -8,10 +8,16 @@ Docker image for the running the HADDOCK system v2.4 for predicting the quartern
 
 2. Open terminal and navigate to the directory of this repository.
 
-3. Run the following command. This will generate the Docker image.
+3. Run the following command. This will generate the Docker image.  
+This builds for 24 cores by default.  
 ```
 docker build -t haddock2_4 .
 ```
+Optionally, you may override the number of cores used. e.g. for 64 cores  
+```
+docker build -t haddock2_4 . --build-arg CORES=64
+```  
+
 
 4. Once the container is ready, remote into the tcsh terminal.
 ```


### PR DESCRIPTION
This adds the CORES build argument which allows you to control how many parallel threads HADDOCK can run simultaneously.

CORES build argument gets passed into the NUMJOB environment variable which is used at compile-time/install-time for CNS. 

In conclusion, this means the number of threads cannot be set at runtime, rather it is baked into the resulting HADDOCK image.