### PR TITLE
Jaimes haddock3 cns fix

### DIFF
--- a/HADDOCK3/Dockerfile
+++ b/HADDOCK3/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.9
+FROM python:3.9-buster
 
 LABEL maintainer="Colby T. Ford <colby@tuple.xyz>"
 
 ENV DEBIAN_FRONTEND noninteractive
 USER root
 
+# gfortran-9 is the latest supported by CNS
+# Debian Bullseye (11) is the latest that has it, but it can't be found by CNS
+# Debian Buster (10) installs gfortran-8 by default with "gfortran"
 RUN apt-get update && \
     apt-get install -y \
         build-essential \
@@ -13,6 +16,7 @@ RUN apt-get update && \
         wget \
         cmake \
         gfortran \
+        flex \
         csh && \
     apt-get clean 
 
@@ -39,10 +43,10 @@ RUN export CNS=/software/cns_solve && \
     sed -i 's/_CNSsolve_location_/\/software\/cns_solve/g' $CNS/cns_solve_env && \
     chmod -R 777 /software && \
     cd $CNS && \
-    make install
+    make install compiler=gfortran
 
 RUN mkdir -p /software/haddock3/bin/ && \
-    ln -s /software/cns_solve/intel-x86_64bit-linux/source/cns_solve-1111091055.exe /software/haddock3/bin/cns
+    ln -s /software/cns_solve/intel-x86_64bit-linux/source/*.exe /software/haddock3/bin/cns
 
 ## Compile HADDOCK
 RUN cd /software/haddock3/src/fcc/src && \

--- a/HADDOCK3/Dockerfile
+++ b/HADDOCK3/Dockerfile
@@ -11,18 +11,39 @@ RUN apt-get update && \
         git \
         nano \
         wget \
-        cmake
+        cmake \
+        csh && \
+    apt-get clean 
 
 ## Make software directory
 RUN mkdir /software
 WORKDIR /software
 
-## Install HADDOCK 3 (https://github.com/haddocking/haddock3)
+## Checkout HADDOCK 3 and custom cns1.3 files
+## (https://github.com/haddocking/haddock3)
 RUN git clone --recursive https://github.com/haddocking/haddock3.git && \
     cd haddock3 && \
     ## v3.0.0-beta.3
     git checkout 1cca9b5
 
+## Install CNSsolve (http://cns-online.org/v1.3/)
+COPY cns_solve_1.3_all_intel-mac_linux.tar.gz /software/
+
+# the custom cns1.3 files are from the HADDOCK3 repo under "varia"
+RUN export CNS=/software/cns_solve && \
+    tar -xzf /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
+    mv /software/cns_solve_1.3/ $CNS && \
+    rm /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
+    cp -r /software/haddock3/varia/cns1.3 $CNS/source && \
+    sed -i 's/_CNSsolve_location_/$CNS/g' $CNS/cns_solve_env && \
+    chmod -R 777 /software && \
+    cd $CNS && \
+    make install
+
+RUN mkdir -p /software/haddock3/bin/ && \
+    ln -s /software/cns_solve/intel-x86_64bit-linux/source/cns_solve-1111091055.exe /software/haddock3/bin/cns
+
+## Compile HADDOCK
 RUN cd /software/haddock3/src/fcc/src && \
     chmod u+x Makefile && \
     make
@@ -30,16 +51,5 @@ RUN cd /software/haddock3/src/fcc/src && \
 RUN cd /software/haddock3 && \
     pip install -r requirements.txt && \
     python setup.py develop --no-deps
-
-## Install CNSsolve (http://cns-online.org/v1.3/)
-COPY cns_solve_1.3_all_intel-mac_linux.tar.gz /software/
-
-RUN tar -xzf /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
-    mv /software/cns_solve_1.3/ /software/cns_solve/ && \
-    rm /software/cns_solve_1.3_all_intel-mac_linux.tar.gz
-
-RUN mkdir -p /software/haddock3/bin/ && \
-    ln -s /software/cns_solve/intel-x86_64bit-linux/source/cns_solve-1111091055.exe /software/haddock3/bin/cns
-
 
 WORKDIR /software/haddock3

--- a/HADDOCK3/Dockerfile
+++ b/HADDOCK3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster
+FROM python:3.9-bullseye
 
 LABEL maintainer="Colby T. Ford <colby@tuple.xyz>"
 
@@ -6,8 +6,8 @@ ENV DEBIAN_FRONTEND noninteractive
 USER root
 
 # gfortran-9 is the latest supported by CNS
-# Debian Bullseye (11) is the latest that has it, but it can't be found by CNS
-# Debian Buster (10) installs gfortran-8 by default with "gfortran"
+# gfortran-10 changed type mismatch warnings to errors
+# Debian Bullseye (11) is the latest with gfortran-9
 RUN apt-get update && \
     apt-get install -y \
         build-essential \
@@ -15,10 +15,11 @@ RUN apt-get update && \
         nano \
         wget \
         cmake \
-        gfortran \
+        gfortran-9 \
         flex \
         csh && \
-    apt-get clean 
+    apt-get clean && \
+    ln -s /usr/bin/gfortran-9 /usr/bin/gfortran
 
 ## Make software directory
 RUN mkdir /software
@@ -39,7 +40,7 @@ RUN export CNS=/software/cns_solve && \
     tar -xzf /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
     mv /software/cns_solve_1.3/ $CNS && \
     rm /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
-    cp -r /software/haddock3/varia/cns1.3 $CNS/source && \
+    cp /software/haddock3/varia/cns1.3/* $CNS/source && \
     sed -i 's/_CNSsolve_location_/\/software\/cns_solve/g' $CNS/cns_solve_env && \
     chmod -R 777 /software && \
     cd $CNS && \

--- a/HADDOCK3/Dockerfile
+++ b/HADDOCK3/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         nano \
         wget \
         cmake \
+        gfortran \
         csh && \
     apt-get clean 
 
@@ -35,7 +36,7 @@ RUN export CNS=/software/cns_solve && \
     mv /software/cns_solve_1.3/ $CNS && \
     rm /software/cns_solve_1.3_all_intel-mac_linux.tar.gz && \
     cp -r /software/haddock3/varia/cns1.3 $CNS/source && \
-    sed -i 's/_CNSsolve_location_/$CNS/g' $CNS/cns_solve_env && \
+    sed -i 's/_CNSsolve_location_/\/software\/cns_solve/g' $CNS/cns_solve_env && \
     chmod -R 777 /software && \
     cd $CNS && \
     make install


### PR DESCRIPTION
This fixes the cns related errors. I got some inspiration to fix cns from the HADDOCK 2.4 Dockerfile.
The HADDOCK3 tests are now working!  

Notes:  
- gfortran-9 is essentially the latest to compile CNS due to the type mismatch warnings which become errors in gfortran-10 and beyond.  
- gfortran-9 is available in default Debian Bullseye (11) repos but not Bookworm (12)  
- Bullseye end of life is 30 Jun 2026  

Some possible future options:  
-  use a different compiler for CNS  
- find a flag to ignore the type mismatch errors in CNS
- find a way to get gfortran-9 on later Debian versions